### PR TITLE
Fix: Correct emergencyWithdraw logic in TokenMaster.sol

### DIFF
--- a/contracts/token/TokenMaster.sol
+++ b/contracts/token/TokenMaster.sol
@@ -207,10 +207,11 @@ contract TokenMaster is Ownable, ReentrancyGuard {
         uint pid = tokenToPid[_token];
         PoolInfo storage pool = poolInfo[pid - 1];
         UserInfo storage user = userInfo[pid][msg.sender];
+        uint256 amountToTransfer = user.amount; // take current user amount
         user.amount = 0;
         user.rewardDebt = 0;
-        IERC20(pool.token).safeTransfer(address(msg.sender), user.amount);
-        emit EmergencyWithdraw(msg.sender, _token, user.amount);
+        IERC20(pool.token).safeTransfer(address(msg.sender), amountToTransfer); // Transfer current user amount 
+        emit EmergencyWithdraw(msg.sender, _token, amountToTransfer);
     }
 
     // Safe ald transfer function, just in case if rounding error causes pool to not have enough ALDs.


### PR DESCRIPTION
### What does this PR do?
This pull request fixes the emergencyWithdraw function in TokenMaster.sol to correctly transfer the user's balance before setting it to zero.

### Detailed Description
- Fixed the emergencyWithdraw function to correctly transfer the user's balance before setting it to zero.
- Updated logic to cache user's amount in a temporary variable (amountToTransfer) before setting user.amount to zero.
- Ensured safeTransfer transfers the correct amount to the user.
- This fix prevents transferring zero balance to the user, ensuring the emergencyWithdraw function works as intended.

### Why is this change needed?
The previous implementation attempted to transfer zero balance to the user because it set the user's amount to zero before calling safeTransfer. This fix ensures the user's balance is transferred correctly, maintaining the integrity of the emergencyWithdraw function.